### PR TITLE
Add persistent PDF block size options

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -16,6 +16,10 @@ function initLocalStorageVars() {
     Glob.initialCubeHeight = loadLocalInt('initialCubeHeight', Glob.initialCubeHeight);
     Glob.initialCubeDimen = loadLocalInt('initialCubeDimen', Glob.initialCubeDimen);
     Glob.cubeDimen = Glob.initialCubeDimen;
+    let defBw = (Glob.initialCubeDimen === 1) ? Glob.defaultBlockWidthPixels : Glob.defaultBlockWidthCubes;
+    let defBh = (Glob.initialCubeDimen === 1) ? Glob.defaultBlockHeightPixels : Glob.defaultBlockHeightCubes;
+    Glob.blockWidthCubes = loadLocalIntBounded('blockWidthCubes', defBw, 1, 20);
+    Glob.blockHeightCubes = loadLocalIntBounded('blockHeightCubes', defBh, 1, 20);
     Glob.pdfDrawLetters = loadLocalBool('pdfDrawLetters', Glob.pdfDrawLetters);
     Glob.bottomToTop = loadLocalBool('bottomToTop', Glob.bottomToTop);
     Glob.pdfBwPrinter = loadLocalBool('pdfBwPrinter', Glob.pdfBwPrinter);

--- a/js/layouts.js
+++ b/js/layouts.js
@@ -212,14 +212,20 @@ function loAdjustPortrait(chooseOptions, opt) {
             $("<input type='number' min='1' max='20'>")
                 .attr('title', 'Block width')
                 .attr('data-prefix', '<span class="fa fa-arrows-alt-h fa-fw"></span>')
-                .val(Glob.cubeDimen === 1 ? Glob.defaultBlockWidthPixels : Glob.defaultBlockWidthCubes)
-                .change(function () {Glob.blockWidthCubes = $(this).val();})
+                .val(Glob.blockWidthCubes)
+                .change(function () {
+                    Glob.blockWidthCubes = parseInt($(this).val());
+                    saveLocal('blockWidthCubes', Glob.blockWidthCubes);
+                })
                 .trigger('change'),
             $("<input type='number' min='1' max='20'>")
                 .attr('title', 'Block height')
                 .attr('data-prefix', '<span class="fa fa-arrows-alt-v fa-fw"></span>')
-                .val(Glob.cubeDimen === 1 ? Glob.defaultBlockHeightPixels : Glob.defaultBlockHeightCubes)
-                .change(function () {Glob.blockHeightCubes = $(this).val();})
+                .val(Glob.blockHeightCubes)
+                .change(function () {
+                    Glob.blockHeightCubes = parseInt($(this).val());
+                    saveLocal('blockHeightCubes', Glob.blockHeightCubes);
+                })
                 .trigger('change')
             );
     let collapsedDiv = $("<div class='collapse card-body border' id='collapsedOpts'>").append(
@@ -265,6 +271,8 @@ function loAdjustPortrait(chooseOptions, opt) {
                 saveLocal('bottomToTop', Glob.bottomToTop);
                 saveLocal('pdfDrawLetters', Glob.pdfDrawLetters);
                 saveLocal('pdfBwPrinter', Glob.pdfBwPrinter);
+                saveLocal('blockWidthCubes', Glob.blockWidthCubes);
+                saveLocal('blockHeightCubes', Glob.blockHeightCubes);
                 setTimeout(() => promoDiv.css('display', 'block'), 300)
             }, 50);
         });

--- a/js/saveload.js
+++ b/js/saveload.js
@@ -38,6 +38,14 @@ function loadLocalInt(name, defaultValue) {
     return (Number.isSafeInteger(result)) ? result : defaultValue;
 }
 
+// @returns loaded integer clamped to [minVal, maxVal]
+function loadLocalIntBounded(name, defaultValue, minVal, maxVal) {
+    let val = loadLocalInt(name, defaultValue);
+    if (!Number.isSafeInteger(val) || val < minVal || val > maxVal)
+        return defaultValue;
+    return val;
+}
+
 // @returns loaded value as boolean
 function loadLocalBool(name, defaultValue) {
     let result = loadLocal(name, defaultValue);


### PR DESCRIPTION
## Summary
- remember PDF block width/height in localStorage
- restore saved block size carefully with boundaries
- persist block size when changed and when generating PDF
- add helper `loadLocalIntBounded`

## Testing
- `npm test` *(fails: could not find package.json)*